### PR TITLE
Found Error for checksyscalls.sh

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -15,6 +15,7 @@
 # Would it be better to run the script after the preprocessor has run?
 #
 
+
 scriptdir=`dirname "$0"`
 #source "$scriptdir/config.sh"
 
@@ -47,7 +48,7 @@ fi
 source "$scriptdir/config.sh"
 
 # we'll pipe files through these commands to remove spurious counts
-rmcomments="scripts/rmcomments.sh"
+rmcomments="/usr/csshare/cs100/src/ucr-cs100/gitlearn/scripts/rmcomments.sh"
 rmstr="sed s/\"[^\"]*\"//g"
 rminclude="sed s/#.*//"
 

--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -48,7 +48,7 @@ fi
 source "$scriptdir/config.sh"
 
 # we'll pipe files through these commands to remove spurious counts
-rmcomments="/usr/csshare/cs100/src/ucr-cs100/gitlearn/scripts/rmcomments.sh"
+rmcomments="$PWD/gitlearn/scripts/rmcomments.sh"
 rmstr="sed s/\"[^\"]*\"//g"
 rminclude="sed s/#.*//"
 


### PR DESCRIPTION
When you run scripts/checksyscalls.sh you get the error that rmcomments.sh is not a file or a directory. In order to fix that you can add "$PWD/gitlearn/scripts/rmcomments.sh". In order to pass in a file you have to do it with the $HOME followed by the path to where the file is, or use the $PWD/ folowed by the path back to where the file it is at. I have attached a picture of the testing done in hammer server.
![screenshot-hammer vgarc018-2](https://cloud.githubusercontent.com/assets/9853737/6068479/473f59f6-ad31-11e4-86b7-954c1ee60d85.png)
