### PR TITLE
added fflush

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -66,6 +66,7 @@ syscalls="
     execvl
     execvp
     fork
+    fflush
     wait
     waitpid
     ioctl


### PR DESCRIPTION
`man fflush` says

```
Upon successful completion 0 is returned.  Otherwise, EOF  is  returned and errno is set to indicate the error.
```

`perror` should be used with `fflush`
