### PR TITLE
Added beginning "skeleton" of website

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rapache"]
+	path = rapache
+	url = https://github.com/mikeizbicki/rapache.git

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,62 @@
+# `gitlearn` Website
+
+Files in this folder are responsible for the structure of the website version of `gitlearn`.
+
+To launch the website, open a terminal, and, once you are in the `gitlearn` repository, run the following commands:
+```
+$ cd rapache
+$ export webroot=../website
+$ ./http.sh
+```
+This will launch the `rapache` webserver.
+You can then view the website by opening your internet browser, and navigating to `http://localhost:8080`.
+This will take you to the homepage, where you can sign in to view your grades.
+
+### Description of Files
+
+##### `authuser.exp`
+
+An `expect` script that checks if the username and password entered are valid credentials.
+It takes username and password as arguments.
+
+Usage:
+```
+./authuser.exp someuser somepassword
+```
+This script is called by `grades`.
+
+##### `calcgrade.sh`
+
+A `bash` script that calculates the grades of the user passed to it as an argument.
+Grades are formatted in an html table.
+
+Usage:
+```
+./calcgrade.sh user
+```
+This script is also called by `grades`.
+
+##### `config.sh`
+
+This is the configuration file for `calcgrade.sh`.
+
+##### `grades`
+
+This bash script is the webpage that users will be directed to in order to view their grades.
+It can be viewed directly by navigating to `http://localhost:8080/grades`.
+You will then be prompted to log in.
+
+`grades` calls `authuser.exp` to authenticate username and password, and then once authenticated, calls `calcgrade.sh` to get the user's grades formatted in a table.
+It then sends this information as a formatted html page to the browser.
+
+##### `index.html`
+
+This is the homepage for the website.
+
+##### `README.md`
+
+This is the file you are currently reading
+
+##### `stylesheet.css`
+
+This contains css formatting for the website.

--- a/website/authuser.exp
+++ b/website/authuser.exp
@@ -1,0 +1,36 @@
+#!/usr/bin/expect
+
+# usage: ./authuser.exp username password
+
+# script checks to see if credentials are correct
+# returns "correct" if username and password are authenticated
+# returns "incorrect" if not authenticated
+# returns "failure" if su command fails
+# return values are sent to stdout
+
+log_user 0
+
+set user [lindex $argv 0]
+set password [lindex $argv 1]
+set timeout 2
+
+spawn /bin/su $user
+
+expect {
+   timeout { send_user "incorrect"; exit 1 }
+   eof { send_user "incorrect"; exit 1 }
+   "*assword:"
+}
+
+send "$password\r"
+
+expect {
+    timeout { send_user "incorrect"; exit 1}
+    "^su:*" { send_user "incorrect"; exit 1}
+    "*\$*"
+}
+
+send_user "correct"
+send "exit\r"
+
+close

--- a/website/authuser.exp
+++ b/website/authuser.exp
@@ -27,10 +27,9 @@ send "$password\r"
 expect {
     timeout { send_user "incorrect"; exit 1}
     "^su:*" { send_user "incorrect"; exit 1}
-    "*\$*"
+    "*\$*" { send_user "correct" }
 }
 
-send_user "correct"
 send "exit\r"
 
 close

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+#
+# This script takes a github account as a parameter.  It then displays all the
+# grades associated with the account
+#
+
+if [ -z "$GITLEARN_CLASSDIR" ]; then
+    scriptdir=`dirname "$0"`
+else
+    scriptdir="$GITLEARN_CLASSDIR/gitlearn/scripts"
+fi
+
+source "$scriptdir/config.sh"
+
+#echo "\$scriptdir is $scriptdir"
+
+########################################
+# check for valid command line params
+
+
+if [ -z $1 ]; then
+    user="$USER"
+else
+    user=$(simplifycsaccount "$1")
+fi
+echo "user=$user"
+echo "\$1=$1"
+
+#######################################
+# check if instructor keys are installed
+
+installInstructorKeys
+
+#######################################
+# calculate stats
+
+echo "finding grade for $(getStudentInfo $user name) ($user)"
+downloadGrades "$user"
+
+totalgrade=$(totalGrade "$user")
+runningtotaloutof=$(runningTotalOutOf "$user")
+totaloutof=$(totalOutOf "$user")
+
+runningpercent=`bc <<< "scale=2; 100 * $totalgrade / $runningtotaloutof"`
+percent=`bc <<< "scale=2; 100 * $totalgrade/$totaloutof"`
+
+#######################################
+# display everything
+
+echo
+echo "==============================================================================="
+echo "    grade        |  assignment                     |  grader"
+echo "==============================================================================="
+
+cd "$tmpdir/$classname-$user"
+for f in `find . -name grade | sort`; do
+    dir=`dirname $f`
+    assn=$(pad "$(basename $dir)" 30)
+    grader=$(git log -n 1 --pretty=format:"%aN" "$f")
+    signature=$(git log -n 1 --pretty=format:"%G?" "$f")
+
+    grade="---"
+    if isGraded "$f"; then
+        grade=$(getGrade "$f")
+    fi
+    outof=$(getOutOf "$f")
+
+    if [ ! $grade = "---" ]; then
+        cmd="scale=2; 100*$grade/$outof"
+        assnPercent=$(bc <<< "$cmd" 2> /dev/null)
+        #colorPercent "$assnPercent"
+        printf "    %3s / %3s    " "$grade" "$outof"
+        #printf "$endcolor|"
+        printf "|"
+        #colorPercent "$assnPercent"
+        #printf "  $assn$endcolor |  $grader "
+        printf "  $assn |  $grader "
+        if [ "$signature" = "G" ]; then
+            #printf "$green[signed]$endcolor"
+            printf "[signed]"
+        else
+            if [ "$signature" = "U" ]; then
+                #printf "$cyn[signed but untrusted]$endcolor"
+                printf "[signed but untrusted]"
+            else
+                printf "[bad signature]"
+            fi
+        fi
+        echo
+    else
+        printf "    %3s / %3s    " "$grade" "$outof"
+        printf "|  $assn |  ---\n"
+    fi
+done
+
+echo "==============================================================================="
+echo
+
+printf "running total = %4s / %4s = " $totalgrade $runningtotaloutof
+dispPercent "$runningpercent"
+printf "  "
+percentToLetter "$runningpercent"
+echo
+printf "overall total = %4s / %4s = " $totalgrade $totaloutof
+dispPercent "$percent"
+printf "  "
+percentToLetter "$percent"
+echo
+echo

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -35,7 +35,20 @@ installInstructorKeys
 #######################################
 # calculate stats
 
-echo "<h2>Grade for $(getStudentInfo $user name) ($user)</h2>"
+studentname=$(getStudentInfo $user name)
+
+if [ -z $studentname ]; then
+    echo "<h2>Grades</h2>"
+    echo "<p>$red Invalid user name.$endcolor</p>"
+    echo "<form action=\"grades\" method=\"GET\">"
+    echo "Please enter a valid cs account:<br>"
+    echo "<input type=\"text\" name=\"user\"><br>"
+    echo "<input type=\"submit\" value=\"Enter\">"
+    echo "</form>"
+    exit
+fi
+
+echo "<h2>Grade for $studentname ($user)</h2>"
 downloadGrades "$user"
 
 totalgrade=$(totalGrade "$user")

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -109,14 +109,16 @@ done
 echo "</table>"
 echo "<br>"
 
-printf "running total = %4s / %4s = " $totalgrade $runningtotaloutof
+echo "<table>"
+echo "<tr>"
+printf "<td>running total</td><td> = </td><td>%4s</td><td>/</td><td>%4s</td><td>=</td><td>" $totalgrade $runningtotaloutof
 dispPercent "$runningpercent"
-printf "  "
+printf "</td><td>"
 percentToLetter "$runningpercent"
-echo
-printf "overall total = %4s / %4s = " $totalgrade $totaloutof
+echo "</td></tr><tr>"
+printf "<td>overall total</td><td> = </td><td>%4s</td><td>/</td><td>%4s</td><td>=</td><td>" $totalgrade $totaloutof
 dispPercent "$percent"
-printf "  "
+printf "</td><td>"
 percentToLetter "$percent"
-echo
-echo
+echo "</td></tr>"
+echo "</table>"

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -5,25 +5,14 @@
 # grades associated with the account
 #
 
-if [ -z "$GITLEARN_CLASSDIR" ]; then
-    scriptdir=`dirname "$0"`
-else
-    scriptdir="$GITLEARN_CLASSDIR/gitlearn/scripts"
-fi
-
-source "$scriptdir/config.sh"
-
-#echo "\$scriptdir is $scriptdir"
+source "$webroot/config.sh"
 
 ########################################
 # check for valid command line params
 
 
-if [ -z $1 ]; then
-    user="$USER"
-else
-    user=$(simplifycsaccount "$1")
-fi
+user=$(simplifycsaccount "$1")
+
 echo "user=$user" >&2
 echo "\$1=$1" >&2
 

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -39,11 +39,11 @@ studentname=$(getStudentInfo $user name)
 
 if [ -z $studentname ]; then
     echo "<h2>Grades</h2>"
-    echo "<p>$red Invalid user name.$endcolor</p>"
-    echo "<form action=\"grades\" method=\"GET\">"
+    echo "<p class=\"error\"><b>Invalid user name.</b></p>"
+    echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
     echo "Please enter a valid cs account:<br>"
     echo "<input type=\"text\" name=\"user\"><br>"
-    echo "<input type=\"submit\" value=\"Enter\">"
+    echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
     echo "</form>"
     exit
 fi
@@ -62,7 +62,7 @@ percent=`bc <<< "scale=2; 100 * $totalgrade/$totaloutof"`
 # display everything
 
 echo "<br>"
-echo "<table>"
+echo "<table id=\"grade\">"
 echo "<tr><th>Grade</th><th>Assignment</th><th>Grader</th></tr>"
 
 cd "$tmpdir/$classname-$user"
@@ -111,14 +111,14 @@ echo "<br>"
 
 echo "<table>"
 echo "<tr>"
-printf "<td>running total</td><td> = </td><td>%4s</td><td>/</td><td>%4s</td><td>=</td><td>" $totalgrade $runningtotaloutof
+printf "<td class=\"grade\">running total</td><td class=\"grade\"> = </td><td class=\"grade\">%4s</td><td class=\"grade\">/</td><td class=\"grade\">%4s</td><td class=\"grade\">=</td><td class=\"grade\">" $totalgrade $runningtotaloutof
 dispPercent "$runningpercent"
-printf "</td><td>"
+printf "</td><td class=\"grade\">"
 percentToLetter "$runningpercent"
 echo "</td></tr><tr>"
-printf "<td>overall total</td><td> = </td><td>%4s</td><td>/</td><td>%4s</td><td>=</td><td>" $totalgrade $totaloutof
+printf "<td class=\"grade\">overall total</td><td class=\"grade\"> = </td><td class=\"grade\">%4s</td><td class=\"grade\">/</td><td class=\"grade\">%4s</td><td class=\"grade\">=</td><td class=\"grade\">" $totalgrade $totaloutof
 dispPercent "$percent"
-printf "</td><td>"
+printf "</td><td class=\"grade\">"
 percentToLetter "$percent"
 echo "</td></tr>"
 echo "</table>"

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -39,12 +39,7 @@ studentname=$(getStudentInfo $user name)
 
 if [ -z $studentname ]; then
     echo "<h2>Grades</h2>"
-    echo "<p class=\"error\"><b>Invalid user name.</b></p>"
-    echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
-    echo "Please enter a valid cs account:<br>"
-    echo "<input type=\"text\" name=\"user\"><br>"
-    echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
-    echo "</form>"
+    echo "<p class=\"error\"><b>You are not enrolled in this class. Please follow the instructions in lab0 to enroll.</b></p>"
     exit
 fi
 
@@ -67,6 +62,7 @@ echo "<tr><th>Grade</th><th>Assignment</th><th>Grader</th></tr>"
 
 cd "$tmpdir/$classname-$user"
 for f in `find . -name grade | sort`; do
+    #echo `cut -d'.' -f2 <<< "$f"` >&2
     echo "<tr>"
     dir=`dirname $f`
     assn=$(pad "$(basename $dir)" 30)

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -49,9 +49,14 @@ echo "<br>"
 echo "<table id=\"grade\">"
 echo "<tr><th>Grade</th><th>Assignment</th><th>Grader</th></tr>"
 
+giturl=$(getStudentInfo $user giturl | sed -e 's/\.git$//')
+
 cd "$tmpdir/$classname-$user"
 for f in `find . -name grade | sort`; do
-    #echo `cut -d'.' -f2 <<< "$f"` >&2
+    githubgradeloc=$(cut -d'.' -f2 <<< "$f")
+    githubassignloc=$(echo $githubgradeloc | sed -e 's/\/grade$//' )
+    githubgradeloc=$giturl/blob/$gradesbranch$githubgradeloc
+    githubassignloc=$giturl/tree/$gradesbranch$githubassignloc
     echo "<tr>"
     dir=`dirname $f`
     assn=$(pad "$(basename $dir)" 30)
@@ -67,13 +72,13 @@ for f in `find . -name grade | sort`; do
     if [ ! $grade = "---" ]; then
         cmd="scale=2; 100*$grade/$outof"
         assnPercent=$(bc <<< "$cmd" 2> /dev/null)
-        echo "<td>"
-        colorPercent "$assnPercent"
+        linkcolor=$(colorPercentLink "$assnPercent")
+        echo "<td><a href=\"$githubgradeloc\" class=\"$linkcolor\">"
         printf "%3s / %3s" "$grade" "$outof"
-        printf "$endcolor</td>"
-        echo "<td>"
-        colorPercent "$assnPercent"
-        printf "$assn$endcolor</td><td>$grader "
+        printf "</a></td>"
+        linkcolor=$(colorPercentLink "$assnPercent")
+        echo "<td><a href=\"$githubassignloc\" class=\"$linkcolor\">"
+        printf "$assn</a></td><td>$grader "
         if [ "$signature" = "G" ]; then
             printf "$green[signed]$endcolor"
         else
@@ -85,8 +90,10 @@ for f in `find . -name grade | sort`; do
         fi
         echo "</td>"
     else
-        printf "<td>%3s / %3s</td>" "$grade" "$outof"
-        printf "<td>$assn</td><td>---</td>"
+        printf "<td><a href=\"$githubgradeloc\" class=\"blacklink\">"
+        printf "%3s / %3s</a></td>" "$grade" "$outof"
+        printf "<td><a href=\"$githubassignloc\" class=\"blacklink\">$assn</a></td>"
+        printf "<td>---</td>"
     fi
     echo "</tr>"
 done

--- a/website/calcgrade.sh
+++ b/website/calcgrade.sh
@@ -24,8 +24,8 @@ if [ -z $1 ]; then
 else
     user=$(simplifycsaccount "$1")
 fi
-echo "user=$user"
-echo "\$1=$1"
+echo "user=$user" >&2
+echo "\$1=$1" >&2
 
 #######################################
 # check if instructor keys are installed
@@ -35,7 +35,7 @@ installInstructorKeys
 #######################################
 # calculate stats
 
-echo "finding grade for $(getStudentInfo $user name) ($user)"
+echo "<h2>Grade for $(getStudentInfo $user name) ($user)</h2>"
 downloadGrades "$user"
 
 totalgrade=$(totalGrade "$user")
@@ -48,13 +48,13 @@ percent=`bc <<< "scale=2; 100 * $totalgrade/$totaloutof"`
 #######################################
 # display everything
 
-echo
-echo "==============================================================================="
-echo "    grade        |  assignment                     |  grader"
-echo "==============================================================================="
+echo "<br>"
+echo "<table>"
+echo "<tr><th>Grade</th><th>Assignment</th><th>Grader</th></tr>"
 
 cd "$tmpdir/$classname-$user"
 for f in `find . -name grade | sort`; do
+    echo "<tr>"
     dir=`dirname $f`
     assn=$(pad "$(basename $dir)" 30)
     grader=$(git log -n 1 --pretty=format:"%aN" "$f")
@@ -69,33 +69,32 @@ for f in `find . -name grade | sort`; do
     if [ ! $grade = "---" ]; then
         cmd="scale=2; 100*$grade/$outof"
         assnPercent=$(bc <<< "$cmd" 2> /dev/null)
-        #colorPercent "$assnPercent"
-        printf "    %3s / %3s    " "$grade" "$outof"
-        #printf "$endcolor|"
-        printf "|"
-        #colorPercent "$assnPercent"
-        #printf "  $assn$endcolor |  $grader "
-        printf "  $assn |  $grader "
+        echo "<td>"
+        colorPercent "$assnPercent"
+        printf "%3s / %3s" "$grade" "$outof"
+        printf "$endcolor</td>"
+        echo "<td>"
+        colorPercent "$assnPercent"
+        printf "$assn$endcolor</td><td>$grader "
         if [ "$signature" = "G" ]; then
-            #printf "$green[signed]$endcolor"
-            printf "[signed]"
+            printf "$green[signed]$endcolor"
         else
             if [ "$signature" = "U" ]; then
-                #printf "$cyn[signed but untrusted]$endcolor"
-                printf "[signed but untrusted]"
+                printf "$cyn[signed but untrusted]$endcolor"
             else
-                printf "[bad signature]"
+                printf "$red[bad signature]$endcolor"
             fi
         fi
-        echo
+        echo "</td>"
     else
-        printf "    %3s / %3s    " "$grade" "$outof"
-        printf "|  $assn |  ---\n"
+        printf "<td>%3s / %3s</td>" "$grade" "$outof"
+        printf "<td>$assn</td><td>---</td>"
     fi
+    echo "</tr>"
 done
 
-echo "==============================================================================="
-echo
+echo "</table>"
+echo "<br>"
 
 printf "running total = %4s / %4s = " $totalgrade $runningtotaloutof
 dispPercent "$runningpercent"

--- a/website/config.sh
+++ b/website/config.sh
@@ -116,7 +116,7 @@ function getStudentInfo {
     # FIXME: this matches any attribute that contains $2 rather than equals $2
     ret=$(awk -F "=" "/^$2/ {print \$2}" "$studentinfo/$csaccount" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     if [ -z "$ret" ]; then
-        error "student $csaccount does not have attribute $2 in their studentinfo file"
+        echo "student $csaccount does not have attribute $2 in their studentinfo file" >&2
     fi
     echo "$ret"
 }

--- a/website/config.sh
+++ b/website/config.sh
@@ -78,12 +78,12 @@ function padPercent {
 
 ##########################################
 #colors
-red="<FONT COLOR=\"FF0000\">"
-green="<FONT COLOR=\"00FF00\">"
-yellow="<FONT COLOR=\"FFFF00\">"
+red="<FONT COLOR=\"C20000\">"
+green="<FONT COLOR=\"006400\">"
+yellow="<FONT COLOR=\"BB8900\">"
 blue="<FONT COLOR=\"0000FF\">"
 mag="<FONT COLOR=\"FF00FF\">"
-cyn="<FONT COLOR=\"00FFFF\">"
+cyn="<FONT COLOR=\"0081A1\">"
 endcolor="</FONT>"
 
 function error {

--- a/website/config.sh
+++ b/website/config.sh
@@ -1,0 +1,513 @@
+#!/bin/bash
+
+#
+# This script contains common configuration settings and functions.
+#
+
+
+# export all variables to subshells
+set -a
+
+#######################################
+# configuration (can be modified)
+
+# the github project name
+classname="ucr-cs100"
+
+# tmp folder for all student repos
+tmpdir="$HOME/.gitlearn/$classname"
+
+# branch of student git repository that stores the grades
+gradesbranch="grades"
+
+# folder containing instructor pgp keys
+instructorinfo="people/instructors"
+
+# folder containing student information
+studentinfo="people/students"
+
+#######################################
+# initialization (do not modify!)
+
+# if gitlearn isn't installed as an env var, then run locally
+if [ -z "$GITLEARN_CLASSDIR" ]; then
+    echo "running local gitlearn at location [$(pwd)]" >&2
+
+    # verify that we are currently in a local gitlearn directory
+    # FIXME: make this a separate function and more robust
+    if [ ! -d "assignments" ] || [ ! -d "people" ]; then
+        echo "error: this does not appear to be a valid gitlearn directory" >&2
+    fi
+
+# otherwise, run in installed folder
+else
+    echo "running installed gitlearn: $GITLEARN_CLASSDIR" >&2
+    # FIXME: validate the installed directory
+    cd $GITLEARN_CLASSDIR
+fi
+
+# let us quit the shell even if we're in a subshell
+trap "exit 1" TERM
+export TOP_PID=$$
+
+function failScript {
+    kill -s TERM $TOP_PID
+}
+
+#######################################
+# misc display functions
+
+# pad the input $1 with extra spaces so that is has exactly length $2
+function pad {
+    ret="${1:0:$2}                                                  "
+    ret="${ret:0:$2}"
+    echo "$ret"
+}
+
+# add the padding to the left
+function padPercent {
+    if [ ${#1} = 5 ]; then
+        printf " "
+    elif [ ${#1} = 4 ]; then
+        printf "  "
+    elif [ "$1" = 0 ]; then
+        printf "  0.0"
+    fi
+    printf "$1"
+}
+
+##########################################
+#colors
+red="<FONT COLOR=\"FF0000\">"
+green="<FONT COLOR=\"00FF00\">"
+yellow="<FONT COLOR=\"FFFF00\">"
+blue="<FONT COLOR=\"0000FF\">"
+mag="<FONT COLOR=\"FF00FF\">"
+cyn="<FONT COLOR=\"00FFFF\">"
+endcolor="</FONT>"
+
+function error {
+    echo -e "$red ERROR: $@$endcolor" >&2
+    failScript
+}
+function warning
+{
+    echo -e "$yellow WARN: $@$endcolor" >&2
+}
+
+#######################################
+# get student info
+
+# prints the names of the csaccount of each student on a separate line
+function getStudentList {
+    for file in $studentinfo/*; do
+        basename "$file"
+    done
+}
+
+# $1 = the student's csaccount (which is the name of file containing their info)
+# $2 = the attribute you want about the student
+function getStudentInfo {
+    csaccount="$1"
+    if [ -z "$2" ]; then
+        error "attribute not given"
+    fi
+
+    # FIXME: this matches any attribute that contains $2 rather than equals $2
+    ret=$(awk -F "=" "/^$2/ {print \$2}" "$studentinfo/$csaccount" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    if [ -z "$ret" ]; then
+        echo "student $csaccount does not have attribute $2 in their studentinfo file" >&2
+    fi
+    echo "$ret"
+}
+
+# $1 = the student's csaccount (which is the name of file containing their info)
+#      OR a string of the form "github=XXX" where XXX is the student's github account
+# output is the student's csaccount
+function simplifycsaccount {
+    local csaccount="$1"
+    if [ $(echo "$1" | cut -d'=' -f 1) = "github" ]; then
+        csaccount="$(github2csaccount $(echo "$1" | cut -d'=' -f 2))"
+    fi
+    echo "$csaccount"
+}
+
+# $1 = the student's github account
+function github2csaccount {
+    local student=$(grep -r "^[[:space:]]*github[[:space:]]*=[[:space:]]*$1[[:space:]]*\$" "$studentinfo" | cut -d':' -f 1)
+    if [ ! -z "$student" ]; then
+        basename "$student"
+    else
+        error "github account $1 is not registered"
+    fi
+}
+
+#######################################
+# download/edit grades
+
+function downloadAllGrades {
+    downloadAllProjects "$classname" "$gradesbranch"
+}
+
+# $1 = csaccount of student to download grades for
+function downloadGrades {
+    giturl="$(getStudentInfo $1 giturl)"
+    clonedir="$tmpdir/$classname-$1"
+    downloadRepo "$clonedir" "$giturl" "$gradesbranch"
+}
+
+# $1 = the name of the repo on github that has the students' projects
+# $2 = [optional] branch of project to enter
+function downloadAllProjects {
+
+    # tells git to keep the username and password in memory for the next 15 minutes
+    git config credential.helper cache
+
+    echo "downloading repos..."
+    accountlist=$(getStudentList)
+
+    # we can only massively parallelize downloads if we've already cloned the repos previously
+    numReposAlreadyDownloaded=$(ls "$tmpdir" | grep "$1" | wc -l)
+    numStudents=$(ls "$studentinfo" | wc -l)
+    if [ "$numReposAlreadyDownloaded" -ge "$numStudents" ]; then
+        maxparallel=100
+    else
+        maxparallel=4
+    fi
+    maxparallel=1
+
+    # this weird xargs command runs all of the downloadProject functions in parallel
+    if ! (echo "$accountlist" | xargs -n 1 -P "$maxparallel" bash -c "downloadProject $1 \$1 $2" -- ); then
+        echo "ERROR: some repos failed to download;"
+        echo "sometimes we exceed github's connection limits due to parallel downloading;"
+        echo "trying again might work?"
+        echo
+        exit 1
+    fi
+    echo "done"
+}
+
+# $1 = project name
+# $2 = csaccount of user
+# $3 = [optional] branch of project to enter
+function downloadProject {
+    github=$(getStudentInfo $2 github)
+    downloadRepo "$tmpdir/$1-$2" "https://github.com/$github/$1.git" "$3"
+}
+
+# $1 = the directory to place the repo
+# $2 = the repo's url (not necessarily on github)
+# $3 = [optional] branch to enter in the repo
+function downloadRepo {
+    local clonedir="$1"
+    local giturl="$2"
+    local branch="$3"
+    local olddir=$(pwd)
+
+    # download repo
+    if [ ! -d "$clonedir" ]; then
+        echo "  running git clone on [$giturl]" >&2
+	    git clone --quiet "$giturl" "$clonedir"
+	    cd "$clonedir"
+
+        # checkout the branch if it's not the default branch
+        # (in that case, it would already be checked out)
+	    local defaultbranch=`git branch -r | grep origin/HEAD | grep -o "[a-zA-Z0-9_-]*$"`
+        if [ ! -z "$branch" ] && [ "$branch" != "$defaultbranch" ]; then
+
+            # if the branch doesn't exist, create it
+            if [ -z "$(git branch --list $branch)" ]; then
+                echo "  $branch doesn't exist in $clonedir... creating branch" >&2
+                git checkout -b "$branch" --quiet
+
+            # the branch exists, so just check it out
+            else
+                echo "  checked out branch $branch in $clonedir" >&2
+                git checkout "$branch" --quiet
+                git pull origin "$branch" --quiet > /dev/null 2> /dev/null
+            fi
+        fi
+    else
+        echo "  running git pull in [$clonedir]" >&2
+        cd "$clonedir"
+        git fetch --all --quiet > /dev/null 2> /dev/null
+
+        if [ -z "$branch" ]; then
+            git checkout --quiet
+            git pull origin master
+        else
+            git checkout "$branch" --quiet
+            git pull origin "$branch" --quiet > /dev/null
+        fi
+
+        ## If branch is empty, assign to it the default branch.
+        ## This assignment cannot occur above as the folder might not even exist then.
+        #if [ -z "$branch" ]; then
+            #branch=`git branch -r | grep origin/HEAD | grep -o "[a-zA-Z0-9_-]*$"`
+        #fi
+        #git checkout "$branch" # --quiet
+        #git pull origin "$branch" # --quiet > /dev/null 2> /dev/null
+    fi
+
+    cd "$olddir"
+}
+
+function uploadAllGrades {
+    # tells git to keep the username and password in memory for the next 15 minutes
+    git config credential.helper cache
+
+    echo "uploading repos..."
+    accountlist=$(getStudentList)
+
+    # this weird xargs command runs all of the uploadGrades functions in parallel
+    maxparallel=1
+    if ! (echo "$accountlist" | xargs -n 1 -P "$maxparallel" bash -c "uploadGrades \$1" -- ); then
+        error "ERROR: some repos failed to upload; sometimes we exceed github's connection limits due to parallel uploading; trying again might work?"
+    fi
+    echo "done"
+}
+
+# $1 = the cs account of the student to upload grades
+function uploadGrades {
+    clonedir="$tmpdir/$classname-$1"
+    cd "$clonedir"
+    for file in `find . -name grade`; do
+        git add $file
+    done
+
+    git commit -S -m "graded assignment for $1 using automatic scripts"
+
+    echo "changes committed... uploading to github"
+    git push origin "$gradesbranch"
+    # FIXME: we should be reporting an error if git fails... but how?
+    #if [ $? ]; then
+        #echo "upload successful :)"
+    #else
+        #echo "upload failed :( error code: $?"
+    #fi
+    cd ../..
+}
+
+# $1 = the csaccount of the student
+# $2 = the assignment to grade
+function gradeAssignment {
+    local csaccount="$1"
+    local assn="$2"
+    local name=$(getStudentInfo "$csaccount" name)
+    local githubaccount=$(getStudentInfo "$csaccount" "github")
+
+    local file="$tmpdir/$classname-$csaccount/$assn/grade"
+
+    mkdir -p `dirname $1`
+
+    # let the grader know who they're grading
+    echo "#####################################" >> "$file"
+    echo "#" >> "$file"
+    echo "# $file" >> "$file"
+    echo "#" >> "$file"
+    echo "# name      = $name" >> "$file"
+    echo "# csaccount = $csaccount" >> "$file"
+    echo "# github    = $githubaccount" >> "$file"
+    echo "#" >> "$file"
+    echo "# any line that begins with a # is a comment and won't be written to the file" >> "$file"
+    echo "#" >> "$file"
+    echo "#####################################" >> "$file"
+
+    vim "$file"
+
+    # delete all the comments from the file
+    sed -i "/^\#/d" "$file"
+}
+
+#######################################
+# parsing grades
+
+# $1 = the grade file
+function isGraded {
+    # is the first word in the file $1 is "/", then it is not graded
+    return `! grep '^[[:blank:]]*/' -q "$1"`
+}
+
+# $1 = the grade file
+function getGrade {
+    head -n 1 "$1" | cut -d'/' -f1 | sed 's/ *//g'
+    #head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
+}
+
+# $1 = the grade file
+function getOutOf {
+    if isGraded $1; then
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $2;}'
+    else
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
+    fi
+}
+
+# calculates the total points for user $1 in directory $2
+function totalGrade {
+    local totalgrade=0
+    local assn="$2"
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        if isGraded "$f"; then
+            local grade=$(getGrade "$f")
+            totalgrade=$(bc <<< "$totalgrade + $grade")
+            #totalgrade=$[$totalgrade+$grade]
+        fi
+    done
+    echo $totalgrade
+}
+
+# calculates the total possible points for user $1 in directory $2 on submitted assignments only
+function runningTotalOutOf {
+    totaloutof=0
+    local assn="$2"
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        if isGraded "$f"; then
+            local outof=$(getOutOf "$f")
+            totaloutof=$(bc <<< "$totaloutof + $outof")
+            #totaloutof=$[$totaloutof+$outof]
+        fi
+    done
+    echo "$totaloutof"
+}
+
+# calculates the total possible points for user $1 in directory $2 on all assignments
+# this function is used for calculating the final grade
+function totalOutOf {
+    totaloutof=0
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        local outof=$(getOutOf "$f")
+        totaloutof=$(bc <<< "$totaloutof + $outof")
+        #totaloutof=$[$totaloutof+$outof]
+    done
+    echo "$totaloutof"
+}
+
+# calculates the current percentage for user $1 in directory $2
+function runningTotalGradePercent {
+    mkPercent $(totalGrade $1 $2) $(runningTotalOutOf $1 $2)
+}
+
+# calculates the final percentage for user $1 in directory $2
+function totalGradePercent {
+    mkPercent $(totalGrade $1 $2) $(totalOutOf $1 $2)
+}
+
+#######################################
+# displaying grades
+
+# $1 = numerator
+# $2 = denominator
+function mkPercent {
+    if [ "$2" = "0" ]; then
+        #echo "NaN"
+        if [ "$1" = "0" ]; then
+            echo "0.00"
+        else
+            echo "100.00"
+        fi
+    else
+        bc <<< "scale=2; 100 * $1/$2"
+    fi
+}
+
+# $1 = percent
+function colorPercent {
+    local per="$1"
+    if [[ -z $1 ]]; then
+        resetColor
+    elif ((`bc <<< "$per>=90"`)); then
+        printf "$green"
+    elif ((`bc <<< "$per>=80"`)); then
+        printf "$cyn"
+    elif ((`bc <<< "$per>=70"`)); then
+        printf "$yellow"
+    else
+        printf "$red"
+    fi
+}
+
+function resetColor {
+    printf "$endcolor"
+}
+
+# $1 = percent
+function dispPercent {
+    local per="$1"
+    colorPercent "$per"
+    printf "$(padPercent $per)"
+    resetColor
+}
+
+# $1 = percent
+function percentToLetter {
+    per="$1"
+    colorPercent "$1"
+    if ((`bc <<< "$per>=97"`)); then
+        printf "A+"
+    elif ((`bc <<< "$per>=93"`)); then
+        printf "A "
+    elif ((`bc <<< "$per>=90"`)); then
+        printf "A-"
+    elif ((`bc <<< "$per>=87"`)); then
+        printf "B+"
+    elif ((`bc <<< "$per>=83"`)); then
+        printf "B "
+    elif ((`bc <<< "$per>=80"`)); then
+        printf "B-"
+    elif ((`bc <<< "$per>=77"`)); then
+        printf "C+"
+    elif ((`bc <<< "$per>=73"`)); then
+        printf "C "
+    elif ((`bc <<< "$per>=70"`)); then
+        printf "C-"
+    elif ((`bc <<< "$per>=67"`)); then
+        printf "D+"
+    elif ((`bc <<< "$per>=63"`)); then
+        printf "D "
+    elif ((`bc <<< "$per>=60"`)); then
+        printf "D-"
+    else
+        printf "F "
+    fi
+    resetColor
+}
+
+##################################
+#checks if a public key is in the instructor files
+# $1 = file to check
+# $2 = key to compare
+function includesKey
+{
+    local instructor=$1
+    local key=$2
+
+    if [ ! -f $instructor ]; then
+        return 1
+    fi
+
+    local instructorKeys=$( gpg --with-fingerprint $instructor | sed -n '/pub/p' | cut -c 12,13,14,15,16,17,18,19 )
+
+    if [[ $instructorKeys == *$key* ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+installInstructorKeys()
+{
+    for file in "$instructorinfo/*"; do
+        gpg --import $file > /dev/null 2> /dev/null
+    done
+}
+

--- a/website/config.sh
+++ b/website/config.sh
@@ -36,7 +36,7 @@ if [ -z "$GITLEARN_CLASSDIR" ]; then
     # verify that we are currently in a local gitlearn directory
     # FIXME: make this a separate function and more robust
     if [ ! -d "assignments" ] || [ ! -d "people" ]; then
-        echo "error: this does not appear to be a valid gitlearn directory"
+        echo "error: this does not appear to be a valid gitlearn directory" >&2
     fi
 
 # otherwise, run in installed folder
@@ -78,13 +78,13 @@ function padPercent {
 
 ##########################################
 #colors
-red="\x1b[31m"
-green="\x1b[32m"
-yellow="\x1b[33m"
-blue="\x1b[34m"
-mag="\x1b[35m"
-cyn="\x1b[36m"
-endcolor="\x1b[0m"
+red="<FONT COLOR=\"FF0000\">"
+green="<FONT COLOR=\"00FF00\">"
+yellow="<FONT COLOR=\"FFFF00\">"
+blue="<FONT COLOR=\"0000FF\">"
+mag="<FONT COLOR=\"FF00FF\">"
+cyn="<FONT COLOR=\"00FFFF\">"
+endcolor="</FONT>"
 
 function error {
     echo -e "$red ERROR: $@$endcolor" >&2
@@ -206,7 +206,7 @@ function downloadRepo {
 
     # download repo
     if [ ! -d "$clonedir" ]; then
-        echo "  running git clone on [$giturl]"
+        echo "  running git clone on [$giturl]" >&2
 	    git clone --quiet "$giturl" "$clonedir"
 	    cd "$clonedir"
 
@@ -228,7 +228,7 @@ function downloadRepo {
             fi
         fi
     else
-        echo "  running git pull in [$clonedir]"
+        echo "  running git pull in [$clonedir]" >&2
         cd "$clonedir"
         git fetch --all --quiet > /dev/null 2> /dev/null
 
@@ -443,15 +443,15 @@ function resetColor {
 # $1 = percent
 function dispPercent {
     local per="$1"
-    #colorPercent "$per"
+    colorPercent "$per"
     printf "$(padPercent $per)"
-    #resetColor
+    resetColor
 }
 
 # $1 = percent
 function percentToLetter {
     per="$1"
-    #colorPercent "$1"
+    colorPercent "$1"
     if ((`bc <<< "$per>=97"`)); then
         printf "A+"
     elif ((`bc <<< "$per>=93"`)); then
@@ -479,7 +479,7 @@ function percentToLetter {
     else
         printf "F "
     fi
-    #resetColor
+    resetColor
 }
 
 ##################################

--- a/website/config.sh
+++ b/website/config.sh
@@ -436,6 +436,22 @@ function colorPercent {
     fi
 }
 
+# $1 = percent
+function colorPercentLink {
+    local per="$1"
+    if [[ -z $1 ]]; then
+        printf "blacklink"
+    elif ((`bc <<< "$per>=90"`)); then
+        printf "greenlink"
+    elif ((`bc <<< "$per>=80"`)); then
+        printf "cynlink"
+    elif ((`bc <<< "$per>=70"`)); then
+        printf "yellowlink"
+    else
+        printf "redlink"
+    fi
+}
+
 function resetColor {
     printf "$endcolor"
 }

--- a/website/config.sh
+++ b/website/config.sh
@@ -1,0 +1,513 @@
+#!/bin/bash
+
+#
+# This script contains common configuration settings and functions.
+#
+
+
+# export all variables to subshells
+set -a
+
+#######################################
+# configuration (can be modified)
+
+# the github project name
+classname="ucr-cs100"
+
+# tmp folder for all student repos
+tmpdir="$HOME/.gitlearn/$classname"
+
+# branch of student git repository that stores the grades
+gradesbranch="grades"
+
+# folder containing instructor pgp keys
+instructorinfo="people/instructors"
+
+# folder containing student information
+studentinfo="people/students"
+
+#######################################
+# initialization (do not modify!)
+
+# if gitlearn isn't installed as an env var, then run locally
+if [ -z "$GITLEARN_CLASSDIR" ]; then
+    echo "running local gitlearn at location [$(pwd)]" >&2
+
+    # verify that we are currently in a local gitlearn directory
+    # FIXME: make this a separate function and more robust
+    if [ ! -d "assignments" ] || [ ! -d "people" ]; then
+        echo "error: this does not appear to be a valid gitlearn directory"
+    fi
+
+# otherwise, run in installed folder
+else
+    echo "running installed gitlearn: $GITLEARN_CLASSDIR" >&2
+    # FIXME: validate the installed directory
+    cd $GITLEARN_CLASSDIR
+fi
+
+# let us quit the shell even if we're in a subshell
+trap "exit 1" TERM
+export TOP_PID=$$
+
+function failScript {
+    kill -s TERM $TOP_PID
+}
+
+#######################################
+# misc display functions
+
+# pad the input $1 with extra spaces so that is has exactly length $2
+function pad {
+    ret="${1:0:$2}                                                  "
+    ret="${ret:0:$2}"
+    echo "$ret"
+}
+
+# add the padding to the left
+function padPercent {
+    if [ ${#1} = 5 ]; then
+        printf " "
+    elif [ ${#1} = 4 ]; then
+        printf "  "
+    elif [ "$1" = 0 ]; then
+        printf "  0.0"
+    fi
+    printf "$1"
+}
+
+##########################################
+#colors
+red="\x1b[31m"
+green="\x1b[32m"
+yellow="\x1b[33m"
+blue="\x1b[34m"
+mag="\x1b[35m"
+cyn="\x1b[36m"
+endcolor="\x1b[0m"
+
+function error {
+    echo -e "$red ERROR: $@$endcolor" >&2
+    failScript
+}
+function warning
+{
+    echo -e "$yellow WARN: $@$endcolor" >&2
+}
+
+#######################################
+# get student info
+
+# prints the names of the csaccount of each student on a separate line
+function getStudentList {
+    for file in $studentinfo/*; do
+        basename "$file"
+    done
+}
+
+# $1 = the student's csaccount (which is the name of file containing their info)
+# $2 = the attribute you want about the student
+function getStudentInfo {
+    csaccount="$1"
+    if [ -z "$2" ]; then
+        error "attribute not given"
+    fi
+
+    # FIXME: this matches any attribute that contains $2 rather than equals $2
+    ret=$(awk -F "=" "/^$2/ {print \$2}" "$studentinfo/$csaccount" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    if [ -z "$ret" ]; then
+        error "student $csaccount does not have attribute $2 in their studentinfo file"
+    fi
+    echo "$ret"
+}
+
+# $1 = the student's csaccount (which is the name of file containing their info)
+#      OR a string of the form "github=XXX" where XXX is the student's github account
+# output is the student's csaccount
+function simplifycsaccount {
+    local csaccount="$1"
+    if [ $(echo "$1" | cut -d'=' -f 1) = "github" ]; then
+        csaccount="$(github2csaccount $(echo "$1" | cut -d'=' -f 2))"
+    fi
+    echo "$csaccount"
+}
+
+# $1 = the student's github account
+function github2csaccount {
+    local student=$(grep -r "^[[:space:]]*github[[:space:]]*=[[:space:]]*$1[[:space:]]*\$" "$studentinfo" | cut -d':' -f 1)
+    if [ ! -z "$student" ]; then
+        basename "$student"
+    else
+        error "github account $1 is not registered"
+    fi
+}
+
+#######################################
+# download/edit grades
+
+function downloadAllGrades {
+    downloadAllProjects "$classname" "$gradesbranch"
+}
+
+# $1 = csaccount of student to download grades for
+function downloadGrades {
+    giturl="$(getStudentInfo $1 giturl)"
+    clonedir="$tmpdir/$classname-$1"
+    downloadRepo "$clonedir" "$giturl" "$gradesbranch"
+}
+
+# $1 = the name of the repo on github that has the students' projects
+# $2 = [optional] branch of project to enter
+function downloadAllProjects {
+
+    # tells git to keep the username and password in memory for the next 15 minutes
+    git config credential.helper cache
+
+    echo "downloading repos..."
+    accountlist=$(getStudentList)
+
+    # we can only massively parallelize downloads if we've already cloned the repos previously
+    numReposAlreadyDownloaded=$(ls "$tmpdir" | grep "$1" | wc -l)
+    numStudents=$(ls "$studentinfo" | wc -l)
+    if [ "$numReposAlreadyDownloaded" -ge "$numStudents" ]; then
+        maxparallel=100
+    else
+        maxparallel=4
+    fi
+    maxparallel=1
+
+    # this weird xargs command runs all of the downloadProject functions in parallel
+    if ! (echo "$accountlist" | xargs -n 1 -P "$maxparallel" bash -c "downloadProject $1 \$1 $2" -- ); then
+        echo "ERROR: some repos failed to download;"
+        echo "sometimes we exceed github's connection limits due to parallel downloading;"
+        echo "trying again might work?"
+        echo
+        exit 1
+    fi
+    echo "done"
+}
+
+# $1 = project name
+# $2 = csaccount of user
+# $3 = [optional] branch of project to enter
+function downloadProject {
+    github=$(getStudentInfo $2 github)
+    downloadRepo "$tmpdir/$1-$2" "https://github.com/$github/$1.git" "$3"
+}
+
+# $1 = the directory to place the repo
+# $2 = the repo's url (not necessarily on github)
+# $3 = [optional] branch to enter in the repo
+function downloadRepo {
+    local clonedir="$1"
+    local giturl="$2"
+    local branch="$3"
+    local olddir=$(pwd)
+
+    # download repo
+    if [ ! -d "$clonedir" ]; then
+        echo "  running git clone on [$giturl]"
+	    git clone --quiet "$giturl" "$clonedir"
+	    cd "$clonedir"
+
+        # checkout the branch if it's not the default branch
+        # (in that case, it would already be checked out)
+	    local defaultbranch=`git branch -r | grep origin/HEAD | grep -o "[a-zA-Z0-9_-]*$"`
+        if [ ! -z "$branch" ] && [ "$branch" != "$defaultbranch" ]; then
+
+            # if the branch doesn't exist, create it
+            if [ -z "$(git branch --list $branch)" ]; then
+                echo "  $branch doesn't exist in $clonedir... creating branch" >&2
+                git checkout -b "$branch" --quiet
+
+            # the branch exists, so just check it out
+            else
+                echo "  checked out branch $branch in $clonedir" >&2
+                git checkout "$branch" --quiet
+                git pull origin "$branch" --quiet > /dev/null 2> /dev/null
+            fi
+        fi
+    else
+        echo "  running git pull in [$clonedir]"
+        cd "$clonedir"
+        git fetch --all --quiet > /dev/null 2> /dev/null
+
+        if [ -z "$branch" ]; then
+            git checkout --quiet
+            git pull origin master
+        else
+            git checkout "$branch" --quiet
+            git pull origin "$branch" --quiet > /dev/null
+        fi
+
+        ## If branch is empty, assign to it the default branch.
+        ## This assignment cannot occur above as the folder might not even exist then.
+        #if [ -z "$branch" ]; then
+            #branch=`git branch -r | grep origin/HEAD | grep -o "[a-zA-Z0-9_-]*$"`
+        #fi
+        #git checkout "$branch" # --quiet
+        #git pull origin "$branch" # --quiet > /dev/null 2> /dev/null
+    fi
+
+    cd "$olddir"
+}
+
+function uploadAllGrades {
+    # tells git to keep the username and password in memory for the next 15 minutes
+    git config credential.helper cache
+
+    echo "uploading repos..."
+    accountlist=$(getStudentList)
+
+    # this weird xargs command runs all of the uploadGrades functions in parallel
+    maxparallel=1
+    if ! (echo "$accountlist" | xargs -n 1 -P "$maxparallel" bash -c "uploadGrades \$1" -- ); then
+        error "ERROR: some repos failed to upload; sometimes we exceed github's connection limits due to parallel uploading; trying again might work?"
+    fi
+    echo "done"
+}
+
+# $1 = the cs account of the student to upload grades
+function uploadGrades {
+    clonedir="$tmpdir/$classname-$1"
+    cd "$clonedir"
+    for file in `find . -name grade`; do
+        git add $file
+    done
+
+    git commit -S -m "graded assignment for $1 using automatic scripts"
+
+    echo "changes committed... uploading to github"
+    git push origin "$gradesbranch"
+    # FIXME: we should be reporting an error if git fails... but how?
+    #if [ $? ]; then
+        #echo "upload successful :)"
+    #else
+        #echo "upload failed :( error code: $?"
+    #fi
+    cd ../..
+}
+
+# $1 = the csaccount of the student
+# $2 = the assignment to grade
+function gradeAssignment {
+    local csaccount="$1"
+    local assn="$2"
+    local name=$(getStudentInfo "$csaccount" name)
+    local githubaccount=$(getStudentInfo "$csaccount" "github")
+
+    local file="$tmpdir/$classname-$csaccount/$assn/grade"
+
+    mkdir -p `dirname $1`
+
+    # let the grader know who they're grading
+    echo "#####################################" >> "$file"
+    echo "#" >> "$file"
+    echo "# $file" >> "$file"
+    echo "#" >> "$file"
+    echo "# name      = $name" >> "$file"
+    echo "# csaccount = $csaccount" >> "$file"
+    echo "# github    = $githubaccount" >> "$file"
+    echo "#" >> "$file"
+    echo "# any line that begins with a # is a comment and won't be written to the file" >> "$file"
+    echo "#" >> "$file"
+    echo "#####################################" >> "$file"
+
+    vim "$file"
+
+    # delete all the comments from the file
+    sed -i "/^\#/d" "$file"
+}
+
+#######################################
+# parsing grades
+
+# $1 = the grade file
+function isGraded {
+    # is the first word in the file $1 is "/", then it is not graded
+    return `! grep '^[[:blank:]]*/' -q "$1"`
+}
+
+# $1 = the grade file
+function getGrade {
+    head -n 1 "$1" | cut -d'/' -f1 | sed 's/ *//g'
+    #head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
+}
+
+# $1 = the grade file
+function getOutOf {
+    if isGraded $1; then
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $2;}'
+    else
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
+    fi
+}
+
+# calculates the total points for user $1 in directory $2
+function totalGrade {
+    local totalgrade=0
+    local assn="$2"
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        if isGraded "$f"; then
+            local grade=$(getGrade "$f")
+            totalgrade=$(bc <<< "$totalgrade + $grade")
+            #totalgrade=$[$totalgrade+$grade]
+        fi
+    done
+    echo $totalgrade
+}
+
+# calculates the total possible points for user $1 in directory $2 on submitted assignments only
+function runningTotalOutOf {
+    totaloutof=0
+    local assn="$2"
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        if isGraded "$f"; then
+            local outof=$(getOutOf "$f")
+            totaloutof=$(bc <<< "$totaloutof + $outof")
+            #totaloutof=$[$totaloutof+$outof]
+        fi
+    done
+    echo "$totaloutof"
+}
+
+# calculates the total possible points for user $1 in directory $2 on all assignments
+# this function is used for calculating the final grade
+function totalOutOf {
+    totaloutof=0
+    if [ -z "$assn" ]; then
+        assn="."
+    fi
+    for f in `find "$tmpdir/$classname-$1/$assn" -name grade`; do
+        local outof=$(getOutOf "$f")
+        totaloutof=$(bc <<< "$totaloutof + $outof")
+        #totaloutof=$[$totaloutof+$outof]
+    done
+    echo "$totaloutof"
+}
+
+# calculates the current percentage for user $1 in directory $2
+function runningTotalGradePercent {
+    mkPercent $(totalGrade $1 $2) $(runningTotalOutOf $1 $2)
+}
+
+# calculates the final percentage for user $1 in directory $2
+function totalGradePercent {
+    mkPercent $(totalGrade $1 $2) $(totalOutOf $1 $2)
+}
+
+#######################################
+# displaying grades
+
+# $1 = numerator
+# $2 = denominator
+function mkPercent {
+    if [ "$2" = "0" ]; then
+        #echo "NaN"
+        if [ "$1" = "0" ]; then
+            echo "0.00"
+        else
+            echo "100.00"
+        fi
+    else
+        bc <<< "scale=2; 100 * $1/$2"
+    fi
+}
+
+# $1 = percent
+function colorPercent {
+    local per="$1"
+    if [[ -z $1 ]]; then
+        resetColor
+    elif ((`bc <<< "$per>=90"`)); then
+        printf "$green"
+    elif ((`bc <<< "$per>=80"`)); then
+        printf "$cyn"
+    elif ((`bc <<< "$per>=70"`)); then
+        printf "$yellow"
+    else
+        printf "$red"
+    fi
+}
+
+function resetColor {
+    printf "$endcolor"
+}
+
+# $1 = percent
+function dispPercent {
+    local per="$1"
+    #colorPercent "$per"
+    printf "$(padPercent $per)"
+    #resetColor
+}
+
+# $1 = percent
+function percentToLetter {
+    per="$1"
+    #colorPercent "$1"
+    if ((`bc <<< "$per>=97"`)); then
+        printf "A+"
+    elif ((`bc <<< "$per>=93"`)); then
+        printf "A "
+    elif ((`bc <<< "$per>=90"`)); then
+        printf "A-"
+    elif ((`bc <<< "$per>=87"`)); then
+        printf "B+"
+    elif ((`bc <<< "$per>=83"`)); then
+        printf "B "
+    elif ((`bc <<< "$per>=80"`)); then
+        printf "B-"
+    elif ((`bc <<< "$per>=77"`)); then
+        printf "C+"
+    elif ((`bc <<< "$per>=73"`)); then
+        printf "C "
+    elif ((`bc <<< "$per>=70"`)); then
+        printf "C-"
+    elif ((`bc <<< "$per>=67"`)); then
+        printf "D+"
+    elif ((`bc <<< "$per>=63"`)); then
+        printf "D "
+    elif ((`bc <<< "$per>=60"`)); then
+        printf "D-"
+    else
+        printf "F "
+    fi
+    #resetColor
+}
+
+##################################
+#checks if a public key is in the instructor files
+# $1 = file to check
+# $2 = key to compare
+function includesKey
+{
+    local instructor=$1
+    local key=$2
+
+    if [ ! -f $instructor ]; then
+        return 1
+    fi
+
+    local instructorKeys=$( gpg --with-fingerprint $instructor | sed -n '/pub/p' | cut -c 12,13,14,15,16,17,18,19 )
+
+    if [[ $instructorKeys == *$key* ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+installInstructorKeys()
+{
+    for file in "$instructorinfo/*"; do
+        gpg --import $file > /dev/null 2> /dev/null
+    done
+}
+

--- a/website/grades
+++ b/website/grades
@@ -21,6 +21,9 @@ else
     echo $(./website/calcgrade.sh $user)
 fi
 
+echo "<br><br>"
+echo "<a href=\"..\">Home</a>"
+
 echo "</body>"
 
 echo "</html>"

--- a/website/grades
+++ b/website/grades
@@ -4,6 +4,7 @@ echo "<!DOCTYPE html>"
 echo "<html>"
 
 echo "<head>"
+echo "<link type=\"text/css\" rel=\"stylesheet\" href=\"stylesheet.css\" >"
 echo "<title>Grades</title>"
 echo "</head>"
 
@@ -12,10 +13,10 @@ echo "<body>"
 if [ -z "$user" ]
 then
     echo "<h2>Grades</h2>"
-    echo "<form action=\"grades\" method=\"GET\">"
+    echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
     echo "Enter your cs account:<br>"
     echo "<input type=\"text\" name=\"user\"><br>"
-    echo "<input type=\"submit\" value=\"Enter\">"
+    echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
     echo "</form>"
 else
     echo $(./website/calcgrade.sh $user)

--- a/website/grades
+++ b/website/grades
@@ -13,7 +13,7 @@ echo "<body>"
 if [ -z "$user" -o -z "$password" ]
 then
     echo "<h2>Grades</h2>"
-    echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+    echo "<form action=\"grades\" method=\"POST\" class=\"gradeform\">"
     echo "Sign into your cs account to view your grades.<br><br>"
     echo "Username:<br>"
     echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
@@ -27,7 +27,7 @@ else
     if [ "$var" == "incorrect" ]; then
          echo "<h2>Grades</h2>"
          echo "<p class=\"error\"><b>Invalid user name and/or password.</b></p>"
-         echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+         echo "<form action=\"grades\" method=\"POST\" class=\"gradeform\">"
          echo "Sign into your cs account to view your grades.<br><br>"
          echo "Username:<br>"
          echo "<input type=\"text\" name=\"user\"><br>"
@@ -40,7 +40,7 @@ else
      else
          echo "<h2>Grades</h2>"
          echo "<p class=\"error\"><b>Error signing in. Please try again.</b></p>"
-         echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+         echo "<form action=\"grades\" method=\"POST\" class=\"gradeform\">"
          echo "Sign into your cs account to view your grades.<br><br>"
          echo "Username:<br>"
          echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"

--- a/website/grades
+++ b/website/grades
@@ -22,36 +22,33 @@ then
     echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
     echo "</form>"
 else
-#    echo $(echo -e "$password\n" | sudo -Sk -u $user ./website/calcgrade.sh)
-#    echo $(expect -c "spawn su $user; expect \"Password: \"; send \"$password\n\"")
-#    ./website/getgrade.exp
-    var=$(./website/authuser.exp $user $password)
+    var=$($webroot/authuser.exp $user $password)
     echo "var is $var" >&2
-   if [ "$var" == "incorrect" ]; then
-        echo "<h2>Grades</h2>"
-        echo "<p class=\"error\"><b>Invalid user name and/or password.</b></p>"
-        echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
-        echo "Sign into your cs account to view your grades.<br><br>"
-        echo "Username:<br>"
-        echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
-        echo "Password:<br>"
-        echo "<input type=\"password\" name=\"password\"><br>"
-        echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
-        echo "</form>"
-    elif [ "$var" == "correct" ]; then
-        ./website/calcgrade.sh $user
-    else
-        echo "<h2>Grades</h2>"
-        echo "<p class=\"error\"><b>Error signing in. Please try again.</b></p>"
-        echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
-        echo "Sign into your cs account to view your grades.<br><br>"
-        echo "Username:<br>"
-        echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
-        echo "Password:<br>"
-        echo "<input type=\"password\" name=\"password\"><br>"
-        echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
-        echo "</form>"
-    fi
+    if [ "$var" == "incorrect" ]; then
+         echo "<h2>Grades</h2>"
+         echo "<p class=\"error\"><b>Invalid user name and/or password.</b></p>"
+         echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+         echo "Sign into your cs account to view your grades.<br><br>"
+         echo "Username:<br>"
+         echo "<input type=\"text\" name=\"user\"><br>"
+         echo "Password:<br>"
+         echo "<input type=\"password\" name=\"password\"><br>"
+         echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
+         echo "</form>"
+     elif [ "$var" == "correct" ]; then
+         $webroot/calcgrade.sh $user
+     else
+         echo "<h2>Grades</h2>"
+         echo "<p class=\"error\"><b>Error signing in. Please try again.</b></p>"
+         echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+         echo "Sign into your cs account to view your grades.<br><br>"
+         echo "Username:<br>"
+         echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
+         echo "Password:<br>"
+         echo "<input type=\"password\" name=\"password\"><br>"
+         echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
+         echo "</form>"
+     fi
 fi
 
 echo "<br><br>"

--- a/website/grades
+++ b/website/grades
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -z "$user" ]
+    echo "<!DOCTYPE html>"
+    echo "<html>"
+    echo "<form action=\"grades\" method=\"GET\">"
+    echo "Enter your cs account:<br>"
+    echo "<input type=\"text\" name=\"user\">"
+    echo "</form>"
+    echo "</html>"
+else
+    echo $(./calcgrade.sh $user)
+fi

--- a/website/grades
+++ b/website/grades
@@ -10,16 +10,48 @@ echo "</head>"
 
 echo "<body>"
 
-if [ -z "$user" ]
+if [ -z "$user" -o -z "$password" ]
 then
     echo "<h2>Grades</h2>"
     echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
-    echo "Enter your cs account:<br>"
-    echo "<input type=\"text\" name=\"user\"><br>"
+    echo "Sign into your cs account to view your grades.<br><br>"
+    echo "Username:<br>"
+    echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
+    echo "Password:<br>"
+    echo "<input type=\"password\" name=\"password\"><br>"
     echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
     echo "</form>"
 else
-    echo $(./website/calcgrade.sh $user)
+#    echo $(echo -e "$password\n" | sudo -Sk -u $user ./website/calcgrade.sh)
+#    echo $(expect -c "spawn su $user; expect \"Password: \"; send \"$password\n\"")
+#    ./website/getgrade.exp
+    var=$(./website/authuser.exp $user $password)
+    echo "var is $var" >&2
+   if [ "$var" == "incorrect" ]; then
+        echo "<h2>Grades</h2>"
+        echo "<p class=\"error\"><b>Invalid user name and/or password.</b></p>"
+        echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+        echo "Sign into your cs account to view your grades.<br><br>"
+        echo "Username:<br>"
+        echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
+        echo "Password:<br>"
+        echo "<input type=\"password\" name=\"password\"><br>"
+        echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
+        echo "</form>"
+    elif [ "$var" == "correct" ]; then
+        ./website/calcgrade.sh $user
+    else
+        echo "<h2>Grades</h2>"
+        echo "<p class=\"error\"><b>Error signing in. Please try again.</b></p>"
+        echo "<form action=\"grades\" method=\"GET\" class=\"gradeform\">"
+        echo "Sign into your cs account to view your grades.<br><br>"
+        echo "Username:<br>"
+        echo "<input type=\"text\" name=\"user\" value=\"$user\"><br>"
+        echo "Password:<br>"
+        echo "<input type=\"password\" name=\"password\"><br>"
+        echo "<input type=\"submit\" value=\"Enter\" class=\"button\">"
+        echo "</form>"
+    fi
 fi
 
 echo "<br><br>"

--- a/website/grades
+++ b/website/grades
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+echo "<!DOCTYPE html>"
+echo "<html>"
+
 if [ -z "$user" ]
-    echo "<!DOCTYPE html>"
-    echo "<html>"
+then
+    echo "<h2>Grades</h2>"
     echo "<form action=\"grades\" method=\"GET\">"
     echo "Enter your cs account:<br>"
-    echo "<input type=\"text\" name=\"user\">"
+    echo "<input type=\"text\" name=\"user\"><br>"
+    echo "<input type=\"submit\" value=\"Enter\">"
     echo "</form>"
-    echo "</html>"
 else
-    echo $(./calcgrade.sh $user)
+    echo $(./website/calcgrade.sh $user)
 fi
+
+echo "</html>"

--- a/website/grades
+++ b/website/grades
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "<!DOCTYPE html>"
+echo "<html>"
+
+echo "<head>"
+echo "<title>Grades</title>"
+echo "</head>"
+
+echo "<body>"
+
+if [ -z "$user" ]
+then
+    echo "<h2>Grades</h2>"
+    echo "<form action=\"grades\" method=\"GET\">"
+    echo "Enter your cs account:<br>"
+    echo "<input type=\"text\" name=\"user\"><br>"
+    echo "<input type=\"submit\" value=\"Enter\">"
+    echo "</form>"
+else
+    echo $(./website/calcgrade.sh $user)
+fi
+
+echo "<br><br>"
+echo "<a href=\"..\">Home</a>"
+
+echo "</body>"
+
+echo "</html>"

--- a/website/grades
+++ b/website/grades
@@ -3,6 +3,12 @@
 echo "<!DOCTYPE html>"
 echo "<html>"
 
+echo "<head>"
+echo "<title>Grades</title>"
+echo "</head>"
+
+echo "<body>"
+
 if [ -z "$user" ]
 then
     echo "<h2>Grades</h2>"
@@ -14,5 +20,7 @@ then
 else
     echo $(./website/calcgrade.sh $user)
 fi
+
+echo "</body>"
 
 echo "</html>"

--- a/website/index.html
+++ b/website/index.html
@@ -12,8 +12,11 @@
 <p><b>Welcome to the class page for CS100!</b></p>
 
 <form action="grades" method="GET" class="gradeform">
-Enter your cs account to view your grades:<br>
+Sign into your cs account to view your grades.<br><br>
+Username:<br>
 <input type="text" name="user"><br>
+Password:<br>
+<input type="password" name="password"><br>
 <input type="submit" class="button" value="Enter"><br>
 </form>
 

--- a/website/index.html
+++ b/website/index.html
@@ -3,18 +3,29 @@
 <html>
 
 <head>
+<link type="text/css" rel="stylesheet" href="stylesheet.css">
 <title>UCR CS100</title>
 </head>
 
 <body>
 <h1>UCR CS100 Class Portal</h1>
-<p>Welcome to the class page for CS100!</p>
-<p>Click on any of the helpful links below.</p>
+<p><b>Welcome to the class page for CS100!</b></p>
 
-<ul style="list-style-type:none">
-  <li><a href="grades">Grades</a></li>
-  <li><a href="https://github.com/mikeizbicki/ucr-cs100/">Class GitHub page</a></li>
-</ul>
+<form action="grades" method="GET" class="gradeform">
+Enter your cs account to view your grades:<br>
+<input type="text" name="user"><br>
+<input type="submit" class="button" value="Enter"><br>
+</form>
+
+<br>
+
+<p><b>Helpful Links:</b></p>
+
+<a href="https://github.com/mikeizbicki/ucr-cs100/">Class GitHub page</a><br>
+<a href="http://www.stackoverflow.com/">Stackoverflow</a><br>
+<a href="http://www.reddit.com/r/programming">Programming on Reddit</a><br>
+<a href="http://slashdot.org/">Slashdot: News for Nerds</a><br>
+<a href="http://news.ycombinator.com/">Hacker News at Y Combinator</a><br>
 
 </body>
 

--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,7 @@
 <h1>UCR CS100 Class Portal</h1>
 <p><b>Welcome to the class page for CS100!</b></p>
 
-<form action="grades" method="GET" class="gradeform">
+<form action="grades" method="POST" class="gradeform">
 Sign into your cs account to view your grades.<br><br>
 Username:<br>
 <input type="text" name="user"><br>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+<title>UCR CS100</title>
+</head>
+
+<body>
+<h1>UCR CS100 Class Portal</h1>
+<p>Welcome to the class page for CS100!</p>
+<p>Click on any of the helpful links below.</p>
+
+<ul style="list-style-type:none">
+  <li><a href="grades">Grades</a></li>
+  <li><a href="https://github.com/mikeizbicki/ucr-cs100/">Class GitHub page</a></li>
+</ul>
+
+</body>
+
+</html>

--- a/website/stylesheet.css
+++ b/website/stylesheet.css
@@ -44,6 +44,51 @@ a:hover {
     text-decoration: underline;
 }
 
+a.redlink {
+    color: #C20000;
+    text-decoration: none;
+}
+
+a.redlink:hover {
+    text-decoration: underline;
+}
+
+a.greenlink {
+    color: #006400;
+    text-decoration: none;
+}
+
+a.greenlink:hover {
+    text-decoration: underline;
+}
+
+a.cynlink {
+    color: #0081A1;
+    text-decoration: none;
+}
+
+a.cynlink:hover {
+    text-decoration: underline;
+}
+
+a.yellowlink {
+    color: #BB8900;
+    text-decoration: none;
+}
+
+a.yellowlink:hover {
+    text-decoration: underline;
+}
+
+a.blacklink {
+    color: #000000;
+    text-decoration: none;
+}
+
+a.blacklink:hover {
+    text-decoration: underline;
+}
+
 p {
     color: #f1ab00;
 }

--- a/website/stylesheet.css
+++ b/website/stylesheet.css
@@ -72,6 +72,21 @@ p {
     line-height:15px;
 }
 
+.gradeform input[type="password"]{
+    border: 1px solid black;
+    background-color: #DED7C8;
+    color: black;
+    height: 25px;
+    margin-bottom: 5px;
+    margin-right: 6px;
+    margin-top: 5px;
+    outline: 0 none;
+    padding: 3px 5px 3px 5px;
+    width: 70%;
+    font-size: 12px;
+    line-height:15px;
+}
+
 .gradeform .button {
     padding: 5px 8px 5px 8px;
     background: #DED7C8;

--- a/website/stylesheet.css
+++ b/website/stylesheet.css
@@ -1,0 +1,90 @@
+h1, h2, h3, h4, h5, h6 {
+    text-align: center;
+    background-color: #F1AB00;
+    border: 1px solid black;
+    padding: 5px;
+}
+
+body {
+    background-color: #2D6CC0;
+    text-align: center;
+    font-family: Impact, Charcoal, sans-serif;
+}
+
+table {
+    background-color: #ded7c8;
+    border-collapse: collapse;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+table, th, td {
+    border: 1px solid black;
+}
+
+td, th {
+    padding: 5px;
+}
+
+th {
+    background-color: #F1AB00;
+}
+
+td.grade {
+    border-style: none;
+}
+
+a {
+    color: #F1AB00;
+    padding: 2px;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+p {
+    color: #f1ab00;
+}
+
+.gradeform {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 400px;
+    background: #F1AB00;
+    padding: 5px;
+    border: 1px solid black;
+}
+
+.gradeform input[type="text"] {
+    border: 1px solid black;
+    background-color: #DED7C8;
+    color: black;
+    height: 25px;
+    margin-bottom: 5px;
+    margin-right: 6px;
+    margin-top: 5px;
+    outline: 0 none;
+    padding: 3px 5px 3px 5px;
+    width: 70%;
+    font-size: 12px;
+    line-height:15px;
+}
+
+.gradeform .button {
+    padding: 5px 8px 5px 8px;
+    background: #DED7C8;
+    border: 1px solid black;
+    color: black;
+    font-size: 12px;
+}
+
+.gradeform .button:hover {
+    background: #2D6CC0;
+}
+
+.error {
+    color: #C20000;
+    background: white;
+}


### PR DESCRIPTION
Website now includes homepage, page for users to enter their cs account to see their grade, and error page if wrong username is entered.

The files for the website version of gitlearn have been included in a new folder called `website`. I actually wasn't sure how to set up where the files would be located for the website, so this is what I settled on. Then to run the website, in the `rapache` submodule, I had to change on line `15` of `http.sh` the path from `./http-stdin.sh` to `./rapache/http-stdin.sh`, as well as the variable `$webroot` in `http-stdin.sh` from `.` to `./website`. Then I could launch the website by typing `./rapache/http.sh` in the main `gitlearn` directory. This makes me think that we should create a separate branch in `rapache` for these changes, and then the submodule can be linked to that branch.

Anyways,  I would like feedback on what I have so far. I also have some ideas on what still can be added, which I'll be posting in the Hw4 Extension issue on `ucr-cs100`.
