### PR TITLE
added new cs100-runtests

### DIFF
--- a/cs100-runtests/README.md
+++ b/cs100-runtests/README.md
@@ -1,0 +1,59 @@
+# cs100-runtests
+
+## About
+``cs100-runtests`` is a script designed to assist testing ``rshell``.
+This ``README`` lists the features of ``cs100-runtests``.
+For a tutorial, checkout [``tutorial.markdown``](./tutorial.markdown).
+
+
+## Usage
+```
+cs100-runtests [shell [testCaseFile]]
+```
+
+## Features
+<!-- This section details how to use the runtests controller. -->
+
+When ``cs100-runtests`` is started, three panes are created in the terminal.
+On the left, ``vim`` edits the ``grade`` file in the current directory.
+In the upper-right, the ``shell`` is started.
+On the bottom-right, the runtests controller awaits commands.
+The runtests controller is used to interact with the ``vim`` and ``shell`` panes.
+If necessary, the other panes can be controlled manually by clicking on them to bring them into focus.
+
+
+#### Controlling the Shell Pane
+* ``n`` or ``next`` goes to the next loaded test case.
+* ``p`` or ``previous`` or ``b`` or ``back`` goes to the previous loaded test case.
+* ``l`` or ``load`` and then a filename loads a test case file.
+The previously loaded test cases are discarded.
+
+  ###### Special Features:
+  * If ``shell`` isn't running in the shell pane, it is restarted.
+    * this allows for multiple ``exit`` commands in the same test file.
+    * the grader is notified when ``shell`` is restarted.
+  * If ``shell`` is suspended, the controller will attempt to make it continue.
+  For this feature to work properly, ``sh`` must have job control enabled.
+
+#### Controlling the Vim Pane
+* ``g`` or ``grade`` followed by ``<line>`` ``<amt>`` puts ``<amt>`` as a grade on ``<line>``. If ``<line>`` isn't a properly-formatted grade line, nothing happens
+* ``f`` ``<line>`` puts a full score on ``<line>``. If ``<line>`` isn't a properly-formatted grade line, nothing happens.
+* ``zero`` makes all scores ``0``
+* ``full`` makes all scores maximum
+
+  ###### Special Features:
+  * After every update, the total is adjusted
+
+#### Controlling the Runtests Controller Pane
+* ``h`` or ``help`` or ``h?`` or ``?h`` or ``?`` or ``??`` print a small help message.
+* ``c`` or ``clear`` clears the controller screen
+* ``e`` or ``exit`` or ``q`` or ``quit`` terminate the ``tmux`` session (closes everything)
+
+  ###### Special Features
+  * Upon receiving ``SIGINT``, ``SIGQUIT``, ``SIGTERM``, or ``SIGTSTP``, the controller terminates the session
+  * The session terminates when ``read`` exits with an error.
+    ``read`` will exit with an error value when the user types ``Control+D`` after nothing else when prompted for a command.
+  * Focus can be shifted from the controller to either the vim instance or the shell instance for manual manipulation by using the mouse.
+  * Pressing enter without entering a command runs the previous command (useful for speeding through test cases)
+  * Displays the previous command in the prompt
+

--- a/cs100-runtests/bin/rshell
+++ b/cs100-runtests/bin/rshell
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# demo "rshell" that does nothing
+
+while read -r -p "$ " line
+do
+  echo "I am an rshell (\"$line\")"
+done

--- a/cs100-runtests/cs100-runtests
+++ b/cs100-runtests/cs100-runtests
@@ -1,0 +1,411 @@
+#!/bin/sh
+
+# sets up and launches cs100-runtests
+
+# prints usage to stderr then quits
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename $0) [shell [testFile]]
+EOF
+  exit 1
+}
+
+
+
+######################################
+# setup (data / functions)
+
+# file edit grades in. Changeable at a later day.
+gradeFile=grade
+
+# unique session and window name
+session="$USER-runtests"
+window="$USER-runtests-window"
+
+
+# prints what's passed in in red
+red() {
+  echo -en "\033[1;31m"
+  echo -n "$@"
+  echo -en "\033[0m"
+}
+
+
+
+######################################
+# parameters
+
+# shell. Defaults to "bin/rshell"
+shell=${1:-bin/rshell}
+# test case file
+testCaseFile=$2
+
+if [ "$shell" != "--controller" ]
+then
+
+  command -v $shell &>/dev/null || {
+    red "$shell"
+    echo ": not found" >&2
+    usage
+  }
+
+
+  # make new session or attach previous if one already exists opens vim on the
+  # grade file
+  tmux -2 new-session -d -n $window -s $session "vim $gradeFile" || {
+    tmux kill-session -t $session
+    tmux -2 new-session -d -n $window -s $session "vim $gradeFile" || {
+      echo "There was a serious problem" >&2; exit 1
+    }
+  }
+
+
+  ### session settings
+  # Mouse support
+  tmux set-option -t $session mouse-select-pane on
+  tmux set-option -t $session mouse-resize-pane on
+  tmux set-option -t $session mouse-select-window on
+  # Set the default terminal mode to 256color mode
+  tmux set-option -t $session default-terminal "screen-256color"
+  # new panes start in current directory
+  tmux set-option -t $session default-path "$PWD"
+  # don't stop server when there are no attached clients
+  tmux set-option -t $session exit-unattached off
+  # if the session becomes unattached, don't kill it
+  tmux set-option -t $session destroy-unattached off
+
+  ### window settings
+  # mouse support for window
+  tmux set-window-option -t $session:$window mode-mouse on
+  tmux set-window-option -t $session:$window allow-rename off
+
+  # split current window vertically, ends up as the top right pane
+  tmux split-window -h "sh"
+  # after pane is created, it is selected
+  # calling list-window and printing pane_pid will give the pid of sh
+  # running in that pane
+  upperRightPID=`tmux list-pane -t $session -F '#{pane_pid}' | tail -1`
+  #echo upperRightPID:$upperRightPID
+  # split right pane horizontally, ends up as the bottom right pane
+  tmux split-window -v -t 1 "$0 --controller $upperRightPID $shell $testCaseFile"
+
+  # show linenumbers in vim (pane 0)
+  tmux send-keys -t 0 ":set number" C-m C-l
+
+  tmux -2 attach -t $session >/dev/null
+
+else
+
+  # todo: add cppcheck, valgind, checksyscalls, etc
+  #echo >>$gradeFile
+  #echo "cppcheck output:" >>$gradeFile
+  #cppcheck src/ &>>$gradeFile
+  #echo >>$gradeFile
+  #echo "valgrind output:" >>$gradeFile
+  #cppcheck src/ &>>$gradeFile
+  #echo >>$gradeFile
+
+
+  upperRightPID=$2
+  shell=$3
+  starterTestCaseFile=$4
+  tempFile=$(mktemp)
+  prevCommand="next"
+  commandIndex=0
+
+  declare -a commandArray
+
+  # function to print its parameters in red
+  # does not insert a newline after printing
+
+  cleanupAndQuit() {
+    rm -rf $tempFile
+    tmux kill-session -t $session
+  }
+
+  trap cleanupAndQuit SIGINT SIGQUIT SIGTERM SIGTSTP
+
+
+  readTestCases() {
+    if [ -z "$1" ]
+    then
+      return
+    elif [ ! -f $1 ]
+    then
+      red "$1"; echo ": file not found"
+      return
+    fi
+
+    index=0
+    commandArray=()
+
+    while read -r line
+    do
+      commandArray[$index]="$line"
+      index=`bc <<< "$index + 1"`
+    done <$1
+
+    unset index
+    echo "Successfully loaded test cases from \"$1\""
+  }
+
+
+
+  shellUp() {
+    if [ ! -z $disabled ]
+    then
+      return 1
+    fi
+
+    if [ `ps --ppid $upperRightPID | wc -l` -le 1 ]
+    then
+      red "shell is not running. starting a new instance... "
+      tmux send-keys -t 1 C-c
+      tmux send-keys -t 1 "$shell" C-m
+      #tmux send-keys -t 1 "valgrind --leak-check=full $shell" C-m
+      if [ `ps --ppid $upperRightPID | wc -l` -le 1 ]
+      then
+        red "failed"; echo
+        disabled=true
+        return 1
+      else
+        red "success"; echo
+        return 0
+      fi
+    elif [ ! -z `ps --ppid $upperRightPID -o state | grep T` ]
+    then
+      red "shell is stopped. attempting to restart... "
+      tmux send-keys -t 1 C-c
+      tmux send-keys -t 1 fg C-m
+      if [ ! -z `ps --ppid $upperRightPID -o state | grep T` ]
+      then
+        red "failed"; echo
+        disabled=true
+        return 1
+      else
+        red "success"; echo
+        return 0
+      fi
+    fi
+  }
+
+
+
+  executeCommand() {
+    shellUp
+    if [ ! -z $disabled ]
+    then
+      red "The controller is disabled. This means that the shell has likely"; echo
+      red "encountered a serious issue and will not stay running."; echo
+      return
+    fi
+    for charIndex in $(seq 0 `bc <<< "${#1} - 1"`)
+    do
+      # send one char
+      # assumes shell is in pane 1
+      tmux send-keys -t 1 "${1:$charIndex:1}"
+    done
+    tmux send-keys -t 1 C-m
+  }
+
+
+  fullGrade() {
+    line=$1
+    outOf=$(cat $gradeFile | head -$line | tail -1 |
+            grep -o '/[[:blank:]]*[[:digit:]][[:digit:].]*[[:blank:]]*\]' |
+            grep -o '[[:digit:].]*')
+    #echo line:$line
+    #echo amt:$amt
+    changeGrade $line $outOf
+    #sed "$line"'s/\[.*\//\['$outOf'\//' $gradeFile >$tempFile &&
+    #cp $tempFile $gradeFile
+  }
+
+
+  changeGrade() {
+    line=$1
+    amt=$2
+    if [[ $line =~ ^[0-9]+$ ]] # line is made of only numbers
+    then
+      if [[ $amt =~ ^[0-9][0-9.]*$ ]] # amt is made of only numbers and '.'
+      then
+        sed "$line"'s/\[.*\//\['$amt'\//' $gradeFile >$tempFile &&
+        cp $tempFile $gradeFile
+      else
+        red $amt; echo ": invalid amount"
+      fi
+    else
+      red $line; echo ": invalid line number"
+    fi
+  }
+
+
+  parseGradeFile() {
+    grep -o '\[[[:blank:]]*[[:digit:].]*[[:blank:]]*/[[:blank:]]*[[:digit:]][[:digit:].]*[[:blank:]]*\]' |
+    grep -o '[[:blank:][:digit:]/.]*'
+  }
+
+
+  updateTotal() {
+    earned=0
+    total=0
+    for val in $(cat $gradeFile | parseGradeFile | cut -d/ -f1)
+    do
+      earned=`bc <<< "$earned + $val"`
+    done
+
+    for val in $(cat $gradeFile | parseGradeFile | cut -d/ -f2)
+    do
+      total=`bc <<< "$total + $val"`
+    done
+
+    sed '1s/.*/'"$earned \\/ $total"'/' $gradeFile >$tempFile &&
+    cp $tempFile $gradeFile
+  }
+
+
+  updateVim() {
+    tmux send-keys -t 0 ':e!' C-m 'gg' C-l
+  }
+
+
+  controllerUsage() {
+    echo -e "Valid commands:"
+    echo -e "n\t\t - next test case"
+    echo -e "p\t\t - previous test case"
+    echo -e "\t\t   + b is an alias of p"
+    echo
+
+    echo -e "g <line> <amt>\t - assign <amt> points to <line> in grade file"
+    echo -e "f <line>\t - assign full points to <line> in grade file"
+    echo -e "zero\t\t - make all grades [ 0 / total ]"
+    echo -e "full\t\t - make all grades [ total / total ]"
+    echo
+        
+    echo -e "h\t\t - print this message"
+    echo -e "c\t\t - clear the screen"
+    echo -e "e\t\t - exit"
+    echo -e "\t\t   + q is an alias of e"
+  }
+
+
+
+  controller() {
+    cmd=$1
+    line=$2
+    file=$2
+    amt=$3
+    if [ ! -z "$cmd" ]
+    then
+      prevCommand="$@"
+    fi
+    case "$cmd" in
+      "") # same as previous
+        controller $prevCommand
+        ;;
+      "h")
+        ;&
+      "h?")
+        ;&
+      "?h")
+        ;&
+      "?")
+        ;&
+      "??")
+        ;&
+      "help")
+        controllerUsage
+        ;;
+      "c")
+        ;&
+      "clear")
+        clear
+        ;;
+      "l") # load testcase
+        ;&
+      "load") # load testcase
+        readTestCases $file
+        ;;
+      "n") # next one command
+        ;&
+      "next") # next one command
+        if [ $commandIndex -lt ${#commandArray[@]} ]
+        then
+          executeCommand "${commandArray[$commandIndex]}"
+          commandIndex=`bc <<< "$commandIndex + 1"`
+        else
+          red "no more test cases"; echo
+        fi
+        ;;
+      "b") # back one command
+        ;&
+      "back")
+        ;&
+      "p")
+        ;&
+      "previous")
+        if [ $commandIndex -gt 0 ]
+        then
+          commandIndex=`bc <<< "$commandIndex - 1"`
+          executeCommand "${commandArray[$commandIndex]}"
+        else
+          red "no previous test case"; echo
+        fi
+        ;;
+      "g")
+        ;&
+      "grade") # grade <line> <amt>
+        changeGrade $line $amt
+        updateTotal
+        updateVim
+        ;;
+      "f") # full grade <line>
+        fullGrade $line
+        updateTotal
+        updateVim
+        ;;
+      "zero") # zero all grades
+        for zeroLine in `seq 1 $(cat $gradeFile | wc -l)`
+        do
+          changeGrade $zeroLine 0
+        done
+        updateTotal
+        updateVim
+        ;;
+      "full") # max all grades
+        for fullLine in `seq 1 $(cat $gradeFile | wc -l)`
+        do
+          fullGrade $fullLine >/dev/null
+        done
+        updateTotal
+        updateVim
+        ;;
+      "q")
+        ;&
+      "quit")
+        ;&
+      "e")
+        ;&
+      "exit")
+        cleanupAndQuit
+        ;;
+      *)
+        red $cmd
+        echo ": invalid command (try h?)"
+    esac
+  }
+
+  # stuff to do before starting:
+  shellUp
+  readTestCases $starterTestCaseFile
+  controllerUsage
+
+  while read -p "command [$prevCommand]: " args
+  do
+    controller $args
+  done
+
+  cleanupAndQuit
+fi
+
+

--- a/cs100-runtests/exampleFolder/exampleTestCaseFile
+++ b/cs100-runtests/exampleFolder/exampleTestCaseFile
@@ -1,0 +1,8 @@
+Test       space      fidelity
+
+/\ blank line
+abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+control-C
+# and back
+
+foregrounded using job control!

--- a/cs100-runtests/exampleFolder/hw0_example
+++ b/cs100-runtests/exampleFolder/hw0_example
@@ -1,0 +1,24 @@
+# this is a comment
+# testing one command:
+ls
+# testing with one parameter:
+ls -a
+# testing with two parameters:
+ls -a -l
+# testing with three parameters:
+ls -a -l -h
+
+# test &&
+true && echo true
+# test ||
+false || echo false
+# test commented exit
+#exit
+# test spaces before commented exit
+    #exit
+# regular exit
+exit
+# rshell is back up when this is run
+# test exit with parameters
+exit --flag -a num 12345
+

--- a/cs100-runtests/exampleFolder/hw1_example
+++ b/cs100-runtests/exampleFolder/hw1_example
@@ -1,0 +1,14 @@
+# this doesn't need to be run through rshell!
+# you can test your ls using bash
+#
+# e.g.
+# cs100-runtests bash
+
+# test regular ls
+bin/ls
+# test ls -a
+bin/ls -a
+# test ls -l
+bin/ls -l
+# test ls -R
+bin/ls -R

--- a/cs100-runtests/exampleFolder/hw2_example
+++ b/cs100-runtests/exampleFolder/hw2_example
@@ -1,0 +1,24 @@
+# test output
+ls > file
+echo "hello world!" > input
+
+# test input
+cat < file
+cat < input
+
+# test appending output
+ls > app
+ls >> app
+ls >> app
+cat app
+
+#test piping
+echo "this is a pipe test" > pipeTest
+cat < pipeTest | grep -v Hello | grep pipe > output && cat output
+
+# cleanup
+rm app
+rm file
+rm input
+rm output
+rm pipeTest

--- a/cs100-runtests/exampleFolder/hw3_example
+++ b/cs100-runtests/exampleFolder/hw3_example
@@ -1,0 +1,32 @@
+# test cd
+pwd
+cd ..
+pwd
+cd rshell
+pwd
+
+# commands from different directories
+# from /usr/bin:
+md5sum --help >/dev/null
+# from /usr/sbin:
+ifconfig >/dev/null
+# from /bin:
+ls >/dev/null
+# from /sbin:
+mkfs --help >/dev/null
+
+# test Ctrl+C
+cat
+
+
+# test Ctrl+C again
+ls -R /
+
+
+# a case for some extra credit:
+cat
+
+ps
+fg
+
+

--- a/cs100-runtests/grade
+++ b/cs100-runtests/grade
@@ -1,0 +1,154 @@
+38 / 40
+
+Grade file
+
+  [2/ 4]
+  [6/ 6]
+  [8/ 8]
+  [10/ 10]
+  [12/ 12]
+
+[] Comment
+  [ This is a test / will not match ]
+  ( unless, of course, "zero" is run. )
+  ( it doesn't depend on validity of fields to put)
+  ( a zero in the right place )
+
+Text can go anywhere. It will not get touched when grading.
+
+  [
+  /
+  29]
+
+  <-20> this is not included with the parsing... yet!
+
+
+Lots of tests:
+
+
+asdf
+
+[asdf]
+[a/a]
+[a/]
+[/a]
+
+[]
+[ ]
+[/]
+[ /]
+[ / ]
+
+[8]
+[ 8]
+[8 ]
+[ 8 ]
+[9.0]
+[ 9.0]
+[9.0 ]
+[ 9.0 ]
+
+[8/]
+[8/7]
+[8/ ]
+[8/ 7]
+[ 8/]
+[ 8/7]
+[ 8/ ]
+[ 8/ 7]
+[8 /]
+[8 /7]
+[8 / ]
+[8 / 7]
+[ 8 /]
+[ 8 /7]
+[ 8 / ]
+[ 8 / 7]
+[9.0/]
+[9.0/34]
+[9.0/ ]
+[9.0/ 34]
+[ 9.0/]
+[ 9.0/34]
+[ 9.0/ ]
+[ 9.0/ 34]
+[9.0 /]
+[9.0 /34]
+[9.0 / ]
+[9.0 / 34]
+[ 9.0 /]
+[ 9.0 /34]
+[ 9.0 / ]
+[ 9.0 / 34]
+
+[8/ ]
+[8/7 ]
+[8/  ]
+[8/ 7 ]
+[ 8/ ]
+[ 8/7 ]
+[ 8/  ]
+[ 8/ 7 ]
+[8 / ]
+[8 /7 ]
+[8 /  ]
+[8 / 7 ]
+[ 8 / ]
+[ 8 /7 ]
+[ 8 /  ]
+[ 8 / 7 ]
+[9.0/ ]
+[9.0/34 ]
+[9.0/ ]
+[9.0/ 34 ]
+[ 9.0/ ]
+[ 9.0/34 ]
+[ 9.0/  ]
+[ 9.0/ 34 ]
+[9.0 / ]
+[9.0 /34 ]
+[9.0 /  ]
+[9.0 / 34 ]
+[ 9.0 / ]
+[ 9.0 /34 ]
+[ 9.0 /  ]
+[ 9.0 / 34 ]
+
+
+asdf [/2] jkl;
+asdf [ /2] jkl;
+asdf [/ 2] jkl;
+asdf [/2 ] jkl;
+asdf [ / 2] jkl;
+asdf [/ 2 ] jkl;
+asdf [ / 2 ] jkl;
+asdf [/3.0] jkl;
+asdf [ /3.0] jkl;
+asdf [/ 3.0] jkl;
+asdf [/3.0 ] jkl;
+asdf [ / 3.0] jkl;
+asdf [/ 3.0 ] jkl;
+asdf [ / 3.0 ] jkl;
+asdf [4/4.0] jkl;
+asdf [ 4/4.0] jkl;
+asdf [4 /4.0] jkl;
+asdf [4/ 4.0] jkl;
+asdf [4/4.0 ] jkl;
+asdf [ 4 /4.0] jkl;
+asdf [4 / 4.0] jkl;
+asdf [4/ 4.0 ] jkl;
+asdf [ 4 / 4.0] jkl;
+asdf [4 / 4.0 ] jkl;
+asdf [ 4 / 4.0 ] jkl;
+asdf [4.0/4.0] jkl;
+asdf [ 4.0/4.0] jkl;
+asdf [4.0 /4.0] jkl;
+asdf [4.0/ 4.0] jkl;
+asdf [4.0/4.0 ] jkl;
+asdf [ 4.0 /4.0] jkl;
+asdf [4.0 / 4.0] jkl;
+asdf [4.0/ 4.0 ] jkl;
+asdf [ 4.0 / 4.0] jkl;
+asdf [4.0 / 4.0 ] jkl;
+asdf [ 4.0 / 4.0 ] jkl;
+

--- a/cs100-runtests/tutorial.markdown
+++ b/cs100-runtests/tutorial.markdown
@@ -1,0 +1,95 @@
+# cs100-runtests Tutorial
+
+## Invocation
+``cs100-runtests`` accepts two parameters.
+All parameters are optional.
+
+* ``shell`` can be any shell (``bin/rshell``, ``sh``, ``bash``, ``ksh``, etc).
+It defaults to ``bin/rshell``
+
+* ``testCaseFile`` is the path to the test cases to load at startup.
+It is possible to load test cases while running.
+Only one file's test cases may be loaded at a time.
+
+
+## What You're Seeing cs100-runtests Do
+In the left pane, ``vim`` is open and editing a grade file.
+The line numbers are turned on so it's easier to grade the assignment.
+All other default ``vim`` settings are preserved.
+``vim`` is manipulated by the controller instance in the bottom right of the ``tmux`` session.
+Because only one pane can be in focus at a time in ``tmux``, the controller will not interfere with edits *when* you make them.
+The controller will, however, discard your changes if you neglect to save them before running another grade-related command.
+
+In the upper-right pane ``shell`` is run inside of ``sh``.
+``sh``'s children are checked every time a command is sent to the ``shell`` pane.
+If ``sh`` doesn't have any children, ``Control-C`` is sent to the ``shell`` pane to get rid of any lingering text (possibly from user's interference).
+Then, ``shell`` is typed and run.
+If ``sh`` has no children at this point, you are notified of the failure and sending test cases becomes disabled.
+
+The ``tmux`` session starts focused on the controller pane.
+This pane runs a script that repeatedly asks for a command.
+It supports commands to change the grade file or run test cases in the upper-right pane.
+To run test cases, it uses ``tmux``'s ``send-keys`` ablility.
+Test cases in the file are sent character by character as if the user had typed them.
+To edit the grade file, ``cs100-runtests`` works behind the scenes then forces vim to update by sending ``:e!<Return>`` (which loads the grade file from the disk).
+If you want to run test cases yourself, click on the ``shell`` pane and run as many as you'd like.
+If you want to edit the grade file yourself, select the ``vim`` pane and edit it.
+Just don't forget to save your changes before going back to the controller!
+
+## Control
+This is a short walkthrough for ``cs100-runtests`` that will cover some of the basic features.
+For a breakdown of all control options, see the [README](./README.md)
+
+Run ``cs100-runtests`` like the following.
+```
+./cs100-runtests bin/rshell exampleFolder/exampleTestCaseFile
+```
+It should be run in the ``cs100-runtests`` folder of the ``gitlearn`` repository.
+
+Start ``cs100-runtests``.
+You'll notice the grade file is open on the left, an example ``rshell`` is open in the upper-right, and the selected pane is the controller in the bottom-right.
+The controller starts by letting you know if your test case file was successfully loaded and printing the commands available to you.
+
+Step through two test cases by pressing ``Enter`` twice.
+This takes advantage of previous command repeating feature.
+If you don't specify a command to run, the previous controller command is rerun.
+Now run the previous test cases by typing ``previous`` and hitting ``Enter``.
+Do this three times.
+The controller does bounds checking so you don't accidentally run more test cases than the amount that exist.
+
+Step forward four times (``next``).
+Space is preserved by the controller, and the text is sent very quickly.
+
+Step through one more case, and...
+Oh no!
+Our ``bin/rshell`` has finished!
+Run the next test case.
+The controller realized that our ``shell`` had finished, so it was restarted.
+Also, you were notified that the ``shell`` needed to be restarted.
+
+Step throught the next case.
+
+This one stops the shell. How is it handled? Try the last case to find out.
+
+The controller attempts to bring the stopped process back using job control.
+
+Trying to run more cases yields and error:
+there are no more test cases.
+To stop running ``cs100-runtests`` type ``exit`` and hit ``Enter``.
+
+## Test Case Format
+Whatever you type in a test case file (newlines and all) will be sent to the ``shell``.
+See the [``exampleFolder/``](./exampleFolder) for example test case files.
+
+## Gradefile Format
+The gradefile format is very lenient.
+The first line is always the total score (or nothing) out of the total possible points for a given assignment.
+After that, anything can go in the file.
+The only lines that are parsed for grades follow this format:
+
+``[<value>/<value>]``
+
+Anything can go before the ``[`` and after the ``]``.
+Also, any amount of whitespace (excluding newlines) can go before or after the ``<value>``.
+``<value>`` is made up of numbers and an optional period, and always starts with a number.
+


### PR DESCRIPTION
combined `cs100-runtests` and `runtests-controller`.
Added documentation (features + tutorial + examples for each assignment)

~~The only thing I noticed when testing on hammer is that `\` doesn't get sent to the `shell`. It appears to be an issue with `read`, and can be remedied by doubling all `\` characters in the test file. This problem doesn't occur on my system (I have a newer version of `bash` than `hammer` does).~~

**EDIT**: the escape character issue has been fixed
