### PR TITLE
fixed escape sequence vulnerability

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -346,16 +346,16 @@ function isGraded {
 
 # $1 = the grade file
 function getGrade {
-    head -n 1 "$1" | cut -d'/' -f1 | sed 's/ *//g'
+    head -n 1 "$1" | cut -d'/' -f1 | sed 's/ *//g' | sed 's/[^[:digit:].]//g'
     #head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
 }
 
 # $1 = the grade file
 function getOutOf {
     if isGraded $1; then
-        head -n 1 "$1" | sed 's/\// /' | awk '{print $2;}'
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $2;}' | sed 's/[^[:digit:].]//g'
     else
-        head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}'
+        head -n 1 "$1" | sed 's/\// /' | awk '{print $1;}' | sed 's/[^[:digit:].]//g'
     fi
 }
 


### PR DESCRIPTION
Using ANSI escape sequences, I have managed to trick the `calcgrade.sh` script into displaying incorrect grades for my quiz0 and quiz1 scores, but this technique can be applied to any assignments. My particular attack has some minor limitations as it assumes the grader has a black background for their terminal and it will change any red text on their screen to black. However, it is conceivable that there exists a similar method that does not have the same limitations.

My proposed fix filters the input from the grade file to ensure that only numbers/decimal points are printed to the screen, thus eliminating the possibility of any control sequence modifying the content of the screen.
# Before fix

![before_fix](https://cloud.githubusercontent.com/assets/5581459/8074641/2c0aceb6-0eea-11e5-932b-32e2df52c119.png)
# After fix

![after_fix](https://cloud.githubusercontent.com/assets/5581459/8074645/2f78493e-0eea-11e5-8682-686ced2eedf0.png)
